### PR TITLE
Apply Fúria theme and navigation updates

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,77 +6,77 @@
 
 @layer base {
   :root {
-    --background: 210 29% 96%; /* #F0F4F8 Very Light Blue */
-    --foreground: 222 47% 11%; /* #1A202C Very Dark Blue/Almost Black */
-    
-    --card: 0 0% 100%; /* White */
-    --card-foreground: 222 47% 11%;
+    --background: 0 0% 0%; /* Preto */
+    --foreground: 0 0% 100%; /* Branco */
 
-    --popover: 0 0% 100%;
-    --popover-foreground: 222 47% 11%;
+    --card: 0 0% 10%; /* Cinza bem escuro */
+    --card-foreground: 0 0% 100%;
 
-    --primary: 223 54% 22%; /* #192A56 Dark Blue */
-    --primary-foreground: 210 20% 98%; /* Light color for text on primary */
+    --popover: 0 0% 10%;
+    --popover-foreground: 0 0% 100%;
 
-    --secondary: 210 25% 90%; 
-    --secondary-foreground: 222 47% 11%;
+    --primary: 266 83% 60%; /* Roxo Fúria */
+    --primary-foreground: 0 0% 100%;
 
-    --muted: 210 25% 88%;
-    --muted-foreground: 210 20% 45%; 
+    --secondary: 0 0% 20%;
+    --secondary-foreground: 0 0% 100%;
 
-    --accent: 328 70% 56%; /* #E03E8D Magenta */
-    --accent-foreground: 0 0% 100%; /* White for text on accent */
+    --muted: 0 0% 25%;
+    --muted-foreground: 0 0% 70%;
+
+    --accent: 266 83% 60%;
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
 
-    --border: 210 20% 85%;
-    --input: 210 20% 92%;
-    --ring: 223 54% 22%; /* Primary color for rings */
+    --border: 0 0% 20%;
+    --input: 0 0% 20%;
+    --ring: 266 83% 60%;
 
     --radius: 0.5rem;
 
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
+    --chart-1: 266 83% 60%;
+    --chart-2: 266 60% 40%;
+    --chart-3: 0 0% 30%;
+    --chart-4: 0 0% 60%;
+    --chart-5: 0 0% 80%;
   }
 
   .dark {
-    --background: 223 20% 10%; 
-    --foreground: 210 29% 90%; 
-    
-    --card: 223 20% 15%;
-    --card-foreground: 210 29% 90%;
+    --background: 0 0% 0%;
+    --foreground: 0 0% 100%;
 
-    --popover: 223 20% 15%;
-    --popover-foreground: 210 29% 90%;
+    --card: 0 0% 10%;
+    --card-foreground: 0 0% 100%;
 
-    --primary: 328 70% 56%; /* Magenta */
-    --primary-foreground: 0 0% 100%; 
+    --popover: 0 0% 10%;
+    --popover-foreground: 0 0% 100%;
 
-    --secondary: 223 20% 20%;
-    --secondary-foreground: 210 29% 90%;
+    --primary: 266 83% 60%;
+    --primary-foreground: 0 0% 100%;
 
-    --muted: 223 20% 20%;
-    --muted-foreground: 210 20% 65%;
+    --secondary: 0 0% 20%;
+    --secondary-foreground: 0 0% 100%;
 
-    --accent: 223 54% 50%; /* Brighter blue */
+    --muted: 0 0% 25%;
+    --muted-foreground: 0 0% 70%;
+
+    --accent: 266 83% 60%;
     --accent-foreground: 0 0% 100%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
 
-    --border: 223 20% 25%;
-    --input: 223 20% 25%;
-    --ring: 328 70% 56%; /* Magenta for rings in dark mode */
-    
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
+    --border: 0 0% 20%;
+    --input: 0 0% 20%;
+    --ring: 266 83% 60%;
+
+    --chart-1: 266 83% 60%;
+    --chart-2: 266 60% 40%;
+    --chart-3: 0 0% 30%;
+    --chart-4: 0 0% 60%;
+    --chart-5: 0 0% 80%;
   }
 }
 

--- a/src/components/courts/AvailabilityCalendar.tsx
+++ b/src/components/courts/AvailabilityCalendar.tsx
@@ -252,16 +252,27 @@ export function AvailabilityCalendar({
           <h4 className="text-md font-semibold mb-2">Inscritos por horário</h4>
           <div className="space-y-3">
             {availableTimeSlots.map(t => {
+              if (!isTimeInPlaySession(currentSelectedDate, t, playSlotsConfig)) return null;
               const dayOfWeek = currentSelectedDate.getDay();
               const cfg = playSlotsConfig.find(s => s.dayOfWeek === dayOfWeek);
               const dateStr = format(currentSelectedDate, 'yyyy-MM-dd');
               const list = cfg ? playSignUps.filter(su => su.slotKey === cfg.key && su.date === dateStr && su.time === t) : [];
+              const me = list.find(su => su.userId === currentUser?.id);
+              const isFull = list.length >= maxParticipantsPerPlaySlot;
               return (
                 <div key={t} className="border rounded-md p-2">
                   <div className="flex items-center justify-between mb-2">
                     <span className="font-medium">{t}</span>
-                    <span className="text-sm text-muted-foreground">{list.length}/{maxParticipantsPerPlaySlot}</span>
+                    <Button
+                      size="sm"
+                      variant={me ? "destructive" : "outline"}
+                      disabled={!me && isFull}
+                      onClick={() => handleTimeSlotClick(t, true)}
+                    >
+                      {me ? "Cancelar" : isFull ? "Esgotado" : "Inscrever-se"}
+                    </Button>
                   </div>
+                  <span className="text-sm text-muted-foreground block mb-2">{list.length}/{maxParticipantsPerPlaySlot}</span>
                   {list.length > 0 ? (
                     <div className="flex flex-wrap gap-2">
                       {list.map(su => (

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -32,7 +32,7 @@ export function AppHeader() {
 
   const navLinksBase = [
     { href: '/', label: 'Início', icon: HomeLucideIcon },
-    // { href: '/play', label: 'Play!', icon: Swords }, // ocultado: inscrição acontece no cartão da quadra
+    { href: '/play', label: 'Play', icon: Swords },
     { href: '/faq', label: 'FAQ', icon: HelpCircle },
   ];
 


### PR DESCRIPTION
## Summary
- restyle app with Fúria black and purple palette
- reintroduce top navigation link for Play sessions
- add signup controls for each timeslot in the availability calendar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: TS7006 etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68af95a9e21083319a0fd1cbe919d96f