### PR TITLE
feat: allow admin to manage user plans

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,7 +2,8 @@
 "use client";
 
 import { useContext } from 'react';
-import { AuthContext, type AuthContextType } from '@/contexts/AuthContext';
+import { AuthContext } from '@/contexts/AuthContext';
+import type { AuthContextType } from '@/lib/types';
 
 export const useAuth = (): AuthContextType => {
   const context = useContext(AuthContext);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -66,6 +66,7 @@ export interface AuthContextType {
   bookings: Booking[];
   playSignUps: PlaySignUp[];
   totalUsers: number;
+  users: User[];
   login: (email: string, pass: string) => Promise<void>;
   signUp: (name: string, email: string, pass: string) => Promise<void>;
   logout: () => Promise<void>;
@@ -76,6 +77,7 @@ export interface AuthContextType {
   // Inscrição no Play; quando time é fornecido, a capacidade/único é por horário
   signUpForPlaySlot: (slotKey: string, date: string, userDetails: { userId: string, userName: string, userEmail: string }, time?: string) => Promise<void>;
   cancelPlaySlotSignUp: (signUpId: string) => Promise<void>;
+  updateUserPlan: (userId: string, planPerWeek: number) => Promise<void>;
   isLoading: boolean;
   authError: string | null;
   clearAuthError: () => void;


### PR DESCRIPTION
## Summary
- list all users in admin dashboard
- allow admins to edit user plan (days per week)
- expose users and plan update API in AuthContext

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: TS7006/TS2345 errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b06294defc8331a22a13f193ec6894