### PR TITLE
Fix login password validation

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -77,11 +77,12 @@ export function LoginForm() {
               id="email"
               type="email"
               placeholder="seu.email@exemplo.com"
-              {...form.register("email")}
+              {...form.register("email", {
+                onChange: () => {
+                  if (authError) clearAuthError();
+                },
+              })}
               disabled={isLoading}
-              onChange={() => {
-                if (authError) clearAuthError();
-              }}
             />
             {form.formState.errors.email && (
               <p className="text-sm text-destructive">{form.formState.errors.email.message}</p>
@@ -100,11 +101,12 @@ export function LoginForm() {
               id="password"
               type="password"
               placeholder="Sua Senha"
-              {...form.register("password")}
+              {...form.register("password", {
+                onChange: () => {
+                  if (authError) clearAuthError();
+                },
+              })}
               disabled={isLoading}
-              onChange={() => {
-                if (authError) clearAuthError();
-              }}
             />
             {/* A mensagem de erro "A senha deve ter pelo menos 6 caracteres." vem da validação Zod (cliente) */}
             {form.formState.errors.password && (


### PR DESCRIPTION
## Summary
- fix password field onChange handlers to ensure proper validation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Next.js ESLint configuration prompt)*
- `npm run typecheck` *(fails: Parameter 'input' implicitly has an 'any' type; Argument of type 'number' is not assignable; Type '() => void' is not assignable to type '() => Promise<void>' )*

------
https://chatgpt.com/codex/tasks/task_e_68b0669c96f4833193a4e3068961104f