### PR TITLE
Disable past time slots on home page

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -31,6 +31,7 @@ export interface TimeSlot {
   time: string; // HH:mm
   isBooked: boolean;
   isPlayTime?: boolean;
+  isPast?: boolean;
 }
 
 export interface PlaySlotConfig {


### PR DESCRIPTION
## Summary
- Track current time in availability calendar and mark past slots as unavailable
- Extend time slot type with `isPast` to support past-time checks

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b7555997088331a42a67666b98fff3