### PR TITLE
Atualiza dia e hora na URL ao entrar no site

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from '@/contexts/AuthContext';
 import { AppHeader } from '@/components/layout/AppHeader';
 import { Toaster } from "@/components/ui/toaster";
 import { cn } from '@/lib/utils';
+import { DateTimeUrlSync } from '@/components/DateTimeUrlSync';
 
 export const metadata: Metadata = {
   title: 'Fúria Treinamentos Futevôlei',
@@ -26,6 +27,7 @@ export default function RootLayout({
     <html lang="pt-BR" suppressHydrationWarning className={`${GeistSans.variable} ${GeistMono.variable}`}>
       <body className={cn("min-h-screen bg-background font-sans antialiased")}>
         <AuthProvider>
+          <DateTimeUrlSync />
           <div className="relative flex min-h-screen flex-col">
             <AppHeader />
             <main className="flex-1 container py-8">

--- a/src/components/DateTimeUrlSync.tsx
+++ b/src/components/DateTimeUrlSync.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+
+export function DateTimeUrlSync() {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const now = new Date();
+    const date = now.toISOString().slice(0, 10);
+    const time = now.toTimeString().slice(0, 5);
+    const params = new URLSearchParams(window.location.search);
+    let updated = false;
+    if (params.get('date') !== date) {
+      params.set('date', date);
+      updated = true;
+    }
+    if (params.get('time') !== time) {
+      params.set('time', time);
+      updated = true;
+    }
+    if (updated) {
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    }
+  }, [router, pathname]);
+
+  return null;
+}
+
+export default DateTimeUrlSync;


### PR DESCRIPTION
## Summary
- Adiciona componente cliente que sincroniza `date` e `time` da URL com a data e hora atuais
- Inclui o sincronizador na raiz do layout para atualizar os parâmetros ao entrar no site

## Testing
- `npm run lint` *(falhou: requereu configuração interativa do ESLint)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bc9365d9d88331b6745aeb7b1b47bd