### PR TITLE
feat: allow admins to confirm aula attendance

### DIFF
--- a/src/components/courts/AvailabilityCalendar.tsx
+++ b/src/components/courts/AvailabilityCalendar.tsx
@@ -208,7 +208,7 @@ export function AvailabilityCalendar({
                       if (slot.isPlayTime) {
                         buttonVariant = meInPlay ? "destructive" : "outline";
                         buttonText = cfg?.timeRange ?? slot.time;
-                        isDisabled = !meInPlay && (playFull || slot.isPast);
+                        isDisabled = !meInPlay && Boolean(playFull || slot.isPast);
                         onClickAction = () => handleTimeSlotClick(slot.time, true);
                         ariaLabel = meInPlay
                           ? `Cancelar inscrição em ${cfg?.timeRange ?? slot.time}`

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,6 +50,9 @@ export interface PlaySignUp {
   date: string; // YYYY-MM-DD, specific date of the Aula session
   time?: string; // HH:mm, opcional quando a inscrição é por horário
   signedUpAt: any; // Firestore Timestamp
+  attended?: boolean; // Presença confirmada pelo admin
+  attendanceConfirmedAt?: any; // Firestore Timestamp
+  attendanceConfirmedBy?: string; // UID do admin que confirmou
 }
 
 import type { ReactNode } from "react";
@@ -91,6 +94,7 @@ export interface AuthContextType {
     time?: string
   ) => Promise<void>;
   cancelPlaySlotSignUp: (signUpId: string) => Promise<void>;
+  setPlaySignUpAttendance: (signUpId: string, attended: boolean) => Promise<void>;
   updateUserPlan: (userId: string, planPerWeek: number) => Promise<void>;
   isLoading: boolean;
   authError: string | null;


### PR DESCRIPTION
## Summary
- allow administradores to confirmar presenças diretamente nos cards de aulas, com destaque visual de quem já teve a presença registrada
- adicionar suporte no contexto de autenticação para persistir o status de presença e armazenar metadados de confirmação
- ajustar o calendário de disponibilidade para garantir coerção booleana e manter o typecheck saudável

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c85e98c420833183d6a69843697420