### PR TITLE
Remove referência a "Quadra Principal" da Refúgio Arena

### DIFF
--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -7,7 +7,7 @@ export const APP_NAME = "Fúria Treinamentos Futevôlei";
 export const courts: Court[] = [
   {
     id: "main-court",
-    name: "Refúgio Arena — Quadra Principal",
+    name: "Refúgio Arena",
     type: "covered",
     imageUrl:
       "https://lh3.googleusercontent.com/p/AF1QipNY9b4RN45xrsy9_66ouZ3YziNstov9vo-1Tpoi=s680-w680-h510-rw",


### PR DESCRIPTION
## Summary
- remove o sufixo "Quadra Principal" do nome configurado para a quadra Refúgio Arena

## Testing
- npm run lint *(falha: comando solicita configuração interativa do ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68c85ea991b88331a3d56c1e7d884723