### PR TITLE
Add Alphaville court slider with fully booked display

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,19 +6,32 @@ import Link from 'next/link';
 import { courts } from '@/config/appConfig';
 import { CourtCard } from '@/components/courts/CourtCard';
 import { AvailabilityCalendar } from '@/components/courts/AvailabilityCalendar';
-import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
-import { CalendarDays } from 'lucide-react';
+import { CalendarDays, ChevronLeft, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export default function HomePage() {
   const [isClient, setIsClient] = useState(false);
+  const [activeCourtIndex, setActiveCourtIndex] = useState(0);
   // Lifted state for globally selected date, initialized to undefined
   const [globallySelectedDate, setGloballySelectedDate] = useState<Date | undefined>(undefined);
+  const hasMultipleCourts = courts.length > 1;
+
+  const goToPreviousCourt = () => {
+    setActiveCourtIndex((prevIndex) => (prevIndex === 0 ? courts.length - 1 : prevIndex - 1));
+  };
+
+  const goToNextCourt = () => {
+    setActiveCourtIndex((prevIndex) => (prevIndex === courts.length - 1 ? 0 : prevIndex + 1));
+  };
 
   useEffect(() => {
     setIsClient(true);
   }, []);
+
+  const sliderStyle = {
+    transform: `translateX(-${activeCourtIndex * 100}%)`,
+  };
 
   return (
     <>
@@ -54,30 +67,71 @@ export default function HomePage() {
         </section>
 
         <section id="courts-section" className="space-y-10">
-          <div className="text-center mb-10 sm:mb-12"> {/* Adjusted spacing */}
+          <div className="text-center mb-10 sm:mb-12">
             <h2 className="text-3xl font-bold tracking-tight text-primary sm:text-4xl">
-              Nossa Quadra
+              Nossas Quadras
             </h2>
             <p className="mt-3 text-lg text-foreground/70">
               Confira os horários e garanta sua vaga.
             </p>
           </div>
-          {courts.map((court, index) => {
-            return (
-              <div key={court.id} className="flex flex-col items-center space-y-6">
-                <CourtCard court={court} className="w-full max-w-3xl" />
-                <AvailabilityCalendar
-                  court={court}
-                  className="w-full max-w-3xl"
-                  currentSelectedDate={globallySelectedDate}
-                  onDateSelect={setGloballySelectedDate}
-                />
-                {index < courts.length - 1 && (
-                  <Separator className="my-8 w-full max-w-3xl" />
-                )}
+          <div className="relative mx-auto w-full max-w-5xl">
+            {hasMultipleCourts && (
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={goToPreviousCourt}
+                className="absolute left-2 top-1/2 z-10 -translate-y-1/2 rounded-full bg-background/90 shadow-md backdrop-blur"
+                aria-label="Ver quadra anterior"
+              >
+                <ChevronLeft className="h-5 w-5" />
+              </Button>
+            )}
+            <div className="overflow-hidden rounded-2xl border border-border bg-background/60 shadow-sm">
+              <div className="flex transition-transform duration-300 ease-in-out" style={sliderStyle}>
+                {courts.map((court) => (
+                  <div key={court.id} className="w-full flex-shrink-0 px-4 py-6">
+                    <div className="flex flex-col items-center space-y-6">
+                      <CourtCard court={court} className="w-full max-w-3xl" />
+                      <AvailabilityCalendar
+                        court={court}
+                        className="w-full max-w-3xl"
+                        currentSelectedDate={globallySelectedDate}
+                        onDateSelect={setGloballySelectedDate}
+                      />
+                    </div>
+                  </div>
+                ))}
               </div>
-            );
-          })}
+            </div>
+            {hasMultipleCourts && (
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={goToNextCourt}
+                className="absolute right-2 top-1/2 z-10 -translate-y-1/2 rounded-full bg-background/90 shadow-md backdrop-blur"
+                aria-label="Ver próxima quadra"
+              >
+                <ChevronRight className="h-5 w-5" />
+              </Button>
+            )}
+            {hasMultipleCourts && (
+              <div className="mt-6 flex justify-center gap-2">
+                {courts.map((court, index) => (
+                  <button
+                    key={court.id}
+                    type="button"
+                    onClick={() => setActiveCourtIndex(index)}
+                    className={cn(
+                      'h-2 w-8 rounded-full transition-colors',
+                      index === activeCourtIndex ? 'bg-primary' : 'bg-muted'
+                    )}
+                    aria-label={`Ir para ${court.name}`}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
         </section>
       </div>
     </>

--- a/src/components/courts/AvailabilityCalendar.tsx
+++ b/src/components/courts/AvailabilityCalendar.tsx
@@ -78,6 +78,11 @@ export function AvailabilityCalendar({
   }, []);
 
   useEffect(() => {
+    if (court.isFullyBooked) {
+      setTimeSlots([]);
+      return;
+    }
+
     if (currentSelectedDate && !authIsLoading) {
       const formattedSelectedDate = format(currentSelectedDate, 'yyyy-MM-dd');
       const isToday = formattedSelectedDate === format(now, 'yyyy-MM-dd');
@@ -109,7 +114,40 @@ export function AvailabilityCalendar({
     } else {
       setTimeSlots([]);
     }
-  }, [currentSelectedDate, court.id, bookings, authIsLoading, now]);
+  }, [currentSelectedDate, court.id, bookings, authIsLoading, now, court.isFullyBooked]);
+
+  if (court.isFullyBooked) {
+    return (
+      <Card className={cn(className)}>
+        <CardHeader>
+          <CardTitle className="text-xl">Verificar Disponibilidade para {court.name}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Horários Esgotados</AlertTitle>
+            <AlertDescription>Todos os horários já reservados para esta quadra.</AlertDescription>
+          </Alert>
+          <p className="text-sm text-muted-foreground text-center">
+            Esta unidade está com 100% de ocupação no momento e é exibida para representar nossa atuação em Alphaville.
+          </p>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+            {availableTimeSlots.map((slot) => (
+              <Button
+                key={slot}
+                variant="destructive"
+                disabled
+                className="w-full"
+                aria-label={`Horário ${slot} esgotado`}
+              >
+                {slot}
+              </Button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
 
   const handleTimeSlotClick = async (time: string, isPlay: boolean = false) => {
     if (!currentUser) {

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -15,6 +15,16 @@ export const courts: Court[] = [
       "Quadra oficial de futevôlei (8m x 16m) na Refúgio Arena, com areia tratada e estrutura confortável.",
     dataAiHint: "futevolei arena refugio",
   },
+  {
+    id: "alphaville-court",
+    name: "Alphaville",
+    type: "covered",
+    imageUrl: "https://placehold.co/600x400?text=Alphaville",
+    description:
+      "Quadra parceira em Alphaville, apresentada para reforçar nossa atuação na região.",
+    dataAiHint: "futevolei quadra alphaville",
+    isFullyBooked: true,
+  },
 ];
 
 export const availableTimeSlots: string[] = ["10:00", "17:00", "18:00", "19:00", "20:00"];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,7 @@ export interface Court {
   imageUrl: string;
   description: string;
   dataAiHint: string;
+  isFullyBooked?: boolean;
 }
 
 export interface Booking {


### PR DESCRIPTION
## Summary
- add Alphaville as a fully booked court to highlight service coverage
- convert the home courts section into a slider with navigation arrows and indicators
- show a dedicated "Horários Esgotados" message and disabled slots when a court is fully booked

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c88a5fd85483319c5fb1d9241415e1