### PR TITLE
Normalize date parsing to local timezone

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { BarChart, LineChart, XAxis, YAxis, CartesianGrid, Tooltip, Legend, Bar, Line, ResponsiveContainer } from 'recharts';
 import { courts, playSlotsConfig } from '@/config/appConfig';
-import { format, subDays, parseISO, eachDayOfInterval, isWithinInterval, startOfDay } from 'date-fns';
+import { format, subDays, eachDayOfInterval, isWithinInterval, startOfDay } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { Activity, BarChart3, CalendarCheck, Users, ShieldAlert, UsersRound, CalendarDays as CalendarIconLucide } from 'lucide-react'; // Renamed to avoid conflict
 import { Skeleton } from '@/components/ui/skeleton';
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
+import { parseLocalDate } from '@/lib/date';
 import type { PlaySignUp, User } from '@/lib/types';
 
 interface ChartData {
@@ -71,7 +72,7 @@ export default function AdminDashboardPage() {
     const end = startOfDay(endDate);
     return playSignUps.filter(ps => {
        try {
-        const signUpDate = parseISO(ps.date);
+        const signUpDate = parseLocalDate(ps.date);
         return isWithinInterval(signUpDate, { start, end });
       } catch (e) {
         console.warn(`Invalid date format for Aula sign up id ${ps.id}: ${ps.date}`);

--- a/src/app/aulas/page.tsx
+++ b/src/app/aulas/page.tsx
@@ -10,8 +10,9 @@ import { playSlotsConfig, numberOfWeeksToDisplayPlaySlots, maxParticipantsPerPla
 import type { PlaySlotConfig } from '@/lib/types';
 import { AulaSlotDisplay } from '@/components/aulas/AulaSlotDisplay';
 import { useAuth } from '@/hooks/useAuth';
-import { format, parseISO, startOfDay, addDays, getDay, nextDay as dateFnsNextDay, type Day } from 'date-fns';
+import { format, startOfDay, getDay, nextDay as dateFnsNextDay, type Day } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
+import { parseLocalDate } from '@/lib/date';
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -114,7 +115,7 @@ function AulasPage() {
           mySlots.push({
             slotConfig: slot,
             date: signUp.date,
-            displayDate: format(parseISO(signUp.date), 'dd/MM', { locale: ptBR }),
+            displayDate: format(parseLocalDate(signUp.date), 'dd/MM', { locale: ptBR }),
             uniqueKey: `${slot.key}-${signUp.date}`,
             hasStarted: false,
           });

--- a/src/components/bookings/BookingCancellationDialog.tsx
+++ b/src/components/bookings/BookingCancellationDialog.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useState } from 'react';
-import { format, parseISO } from 'date-fns';
+import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { Button } from '@/components/ui/button';
 import {
@@ -17,6 +17,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/use-toast';
 import type { Booking } from '@/lib/types';
 import { Loader2, AlertTriangle } from 'lucide-react';
+import { parseLocalDate } from '@/lib/date';
 
 interface BookingCancellationDialogProps {
   isOpen: boolean;
@@ -39,7 +40,7 @@ export function BookingCancellationDialog({
       await cancelBooking(booking.id);
       toast({
         title: "Reserva Cancelada",
-        description: `Sua reserva para ${booking.courtName} em ${format(parseISO(booking.date), "dd/MM/yyyy", { locale: ptBR })} às ${booking.time} foi cancelada com sucesso.`,
+        description: `Sua reserva para ${booking.courtName} em ${format(parseLocalDate(booking.date), "dd/MM/yyyy", { locale: ptBR })} às ${booking.time} foi cancelada com sucesso.`,
         duration: 5000,
       });
       onOpenChange(false);
@@ -71,7 +72,7 @@ export function BookingCancellationDialog({
         {/* Detalhes da reserva movidos para fora do DialogDescription */}
         <div className="mt-4 space-y-1 text-sm text-foreground bg-muted/50 p-3 rounded-md">
           <p><span className="font-medium">Quadra:</span> {booking.courtName} ({booking.courtType === 'covered' ? 'Coberta' : 'Descoberta'})</p>
-          <p><span className="font-medium">Data:</span> {format(parseISO(booking.date), "EEEE, dd 'de' MMMM 'de' yyyy", { locale: ptBR })}</p>
+          <p><span className="font-medium">Data:</span> {format(parseLocalDate(booking.date), "EEEE, dd 'de' MMMM 'de' yyyy", { locale: ptBR })}</p>
           <p><span className="font-medium">Hora:</span> {booking.time}</p>
           <p className="text-xs"><span className="font-medium">ID da Reserva:</span> {booking.id}</p>
         </div>

--- a/src/components/bookings/BookingListItem.tsx
+++ b/src/components/bookings/BookingListItem.tsx
@@ -6,11 +6,12 @@ import type { Booking } from '@/lib/types';
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { CalendarDays, Clock, ShieldCheck, Sun, Trash2, User, Edit3Icon, Users } from 'lucide-react'; // Added Users
-import { format, parseISO } from 'date-fns';
+import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { BookingCancellationDialog } from './BookingCancellationDialog';
-import { EditBookingDialog } from './EditBookingDialog'; 
-import { useAuth } from '@/hooks/useAuth'; 
+import { EditBookingDialog } from './EditBookingDialog';
+import { useAuth } from '@/hooks/useAuth';
+import { parseLocalDate } from '@/lib/date';
 
 interface BookingListItemProps {
   booking: Booking;
@@ -21,7 +22,7 @@ export function BookingListItem({ booking, showUserName = false }: BookingListIt
   const { isAdmin } = useAuth(); 
   const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false); 
-  const bookingDate = parseISO(booking.date);
+  const bookingDate = parseLocalDate(booking.date);
 
   const handleBookingUpdated = () => {
     setIsEditDialogOpen(false);

--- a/src/components/bookings/EditBookingDialog.tsx
+++ b/src/components/bookings/EditBookingDialog.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useState, useEffect } from 'react';
-import { format, parseISO } from 'date-fns';
+import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { Button } from '@/components/ui/button';
 import {
@@ -22,6 +22,7 @@ import type { Booking } from '@/lib/types';
 import { availableTimeSlots } from '@/config/appConfig';
 import { Loader2, CalendarIcon, ClockIcon, UserCircle } from 'lucide-react'; // Adicionado UserCircle
 import { cn } from '@/lib/utils';
+import { parseLocalDate } from '@/lib/date';
 
 interface EditBookingDialogProps {
   isOpen: boolean;
@@ -39,7 +40,7 @@ export function EditBookingDialog({
   const { updateBookingByAdmin, bookings: allBookings } = useAuth();
   const { toast } = useToast();
   const [isUpdating, setIsUpdating] = useState(false);
-  const [selectedDate, setSelectedDate] = useState<Date | undefined>(parseISO(booking.date));
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(parseLocalDate(booking.date));
   const [selectedTime, setSelectedTime] = useState<string>(booking.time);
   const [onBehalfOfName, setOnBehalfOfName] = useState<string>(booking.onBehalfOf || '');
   const [availableSlotsForSelectedDate, setAvailableSlotsForSelectedDate] = useState<string[]>([]);
@@ -62,7 +63,7 @@ export function EditBookingDialog({
   useEffect(() => {
     // Reset form fields when the dialog is reopened with a different booking
     if (isOpen) {
-      setSelectedDate(parseISO(booking.date));
+      setSelectedDate(parseLocalDate(booking.date));
       setSelectedTime(booking.time);
       setOnBehalfOfName(booking.onBehalfOf || '');
     }

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import type { User, Booking, PlaySignUp, AuthContextType, AuthProviderProps } from '@/lib/types';
-import { parseISO, startOfWeek, endOfWeek } from 'date-fns';
+import { startOfWeek, endOfWeek } from 'date-fns';
 import { useRouter, usePathname } from 'next/navigation';
 import { createContext, useState, useEffect, useCallback } from 'react';
 import { 
@@ -33,6 +33,7 @@ import {
 } from 'firebase/firestore';
 import { useToast } from "@/hooks/use-toast";
 import { maxParticipantsPerPlaySlot } from '@/config/appConfig';
+import { parseLocalDate } from '@/lib/date';
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
@@ -497,13 +498,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
       }
       // Limite semanal por plano
       const planLimit = currentUser.planPerWeek ?? 1;
-      const targetDate = parseISO(date);
+      const targetDate = parseLocalDate(date);
       const weekStart = startOfWeek(targetDate, { weekStartsOn: 1 });
       const weekEnd = endOfWeek(targetDate, { weekStartsOn: 1 });
       const mySignUpsThisWeek = playSignUps.filter(su => {
         if (su.userId !== currentUser.id) return false;
         if (su.isExperimental) return false;
-        const suDate = parseISO(su.date);
+        const suDate = parseLocalDate(su.date);
         return suDate >= weekStart && suDate <= weekEnd;
       }).length;
       if (mySignUpsThisWeek >= planLimit) {

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,21 @@
+export function parseLocalDate(dateString: string): Date {
+  if (!dateString) {
+    return new Date(NaN);
+  }
+
+  const parts = dateString.split('-');
+  if (parts.length < 3) {
+    return new Date(dateString);
+  }
+
+  const [yearStr, monthStr, dayStr] = parts;
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return new Date(dateString);
+  }
+
+  return new Date(year, month - 1, day);
+}


### PR DESCRIPTION
## Summary
- add a helper that converts YYYY-MM-DD strings into local Date objects
- update booking UI components plus admin/aulas views to use the helper so the selected day does not shift after refresh
- adjust auth context date handling to leverage the localized parsing when enforcing weekly limits

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated files)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ca115830f48331bf888d13d436514c